### PR TITLE
Added scripts to create and populate DB tables

### DIFF
--- a/create_tables.sql
+++ b/create_tables.sql
@@ -1,7 +1,10 @@
-CREATE EXTENSION IF NOT EXISTS "pg-crypto";
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
-CREATE TYPE STATUS_COLOR AS ENUM ('GREEN', 'ORANGE', 'RED', 'GREY');
-CREATE TYPE DEPLOYMENT_STATUS AS ENUM ('ready-to-deploy', 'not-ready-to-deploy');
+DROP TYPE IF EXISTS STATUS_COLOR;
+CREATE TYPE STATUS_COLOR AS ENUM ('green', 'orange', 'red', 'grey');
+
+DROP TYPE IF EXISTS DEPLOYMENT_STATUS;
+CREATE TYPE DEPLOYMENT_STATUS AS ENUM ('ready', 'paused');
 
 DROP TABLE IF EXISTS users CASCADE;
 CREATE TABLE users (
@@ -15,7 +18,7 @@ CREATE TABLE users (
 DROP TABLE IF EXISTS components CASCADE;
 CREATE TABLE components (
   component_id UUID DEFAULT gen_random_uuid(),
-  user_id SERIAL REFERENCES users(user_id),
+  user_id UUID REFERENCES users(user_id),
   github_repo TEXT NOT NULL,
   deployment_status DEPLOYMENT_STATUS NOT NULL,
   PRIMARY KEY(component_id)
@@ -31,9 +34,9 @@ CREATE TABLE workers (
 DROP TABLE IF EXISTS stats CASCADE;
 CREATE TABLE stats (
   stat_id UUID DEFAULT gen_random_uuid(),
-  worker_id SERIAL REFERENCES workers(worker_id),
-  component_id SERIAL REFERENCES components(component_id),
-  received_time TIMESTAMP NOT NULL,
+  worker_id UUID REFERENCES workers(worker_id),
+  component_id UUID REFERENCES components(component_id),
+  received_time TIMESTAMPTZ NOT NULL,
   color STATUS_COLOR NOT NULL,
   stat_window_seconds DOUBLE PRECISION NOT NULL,
   hits DOUBLE PRECISION NOT NULL,
@@ -46,11 +49,11 @@ CREATE TABLE stats (
 DROP TABLE IF EXISTS logs CASCADE;
 CREATE TABLE logs (
   log_id UUID DEFAULT gen_random_uuid(),
-  worker_id SERIAL REFERENCES workers(worker_id),
-  component_id SERIAL REFERENCES components(component_id),
+  worker_id UUID REFERENCES workers(worker_id),
+  component_id UUID REFERENCES components(component_id),
   execution_num INT NOT NULL,
-  received_time TIMESTAMP NOT NULL,
+  received_time TIMESTAMPTZ NOT NULL,
   log_text TEXT,
-  log_error VASRCHAR(400),
+  log_error TEXT,
   PRIMARY KEY (log_id)
 );

--- a/create_tables.sql
+++ b/create_tables.sql
@@ -1,42 +1,56 @@
-DROP TABLE IF EXISTS logs CASCADE;
-DROP TABLE IF EXISTS stats CASCADE;
-DROP TABLE IF EXISTS workers CASCADE;
-DROP TABLE IF EXISTS components CASCADE;
+CREATE EXTENSION IF NOT EXISTS "pg-crypto";
+
+CREATE TYPE STATUS_COLOR AS ENUM ('GREEN', 'ORANGE', 'RED', 'GREY');
+CREATE TYPE DEPLOYMENT_STATUS AS ENUM ('ready-to-deploy', 'not-ready-to-deploy');
+
 DROP TABLE IF EXISTS users CASCADE;
-
 CREATE TABLE users (
-  user_id SERIAL PRIMARY KEY,
-  email VARCHAR(100) NOT NULL,
-  github_token VARCHAR(100) NOT NULL,
-  github_username VARCHAR(100) NOT NULL
+  user_id UUID DEFAULT gen_random_uuid(),
+  email TEXT NOT NULL,
+  github_token TEXT NOT NULL,
+  github_username TEXT NOT NULL,
+  PRIMARY KEY (user_id)
 );
 
+DROP TABLE IF EXISTS components CASCADE;
 CREATE TABLE components (
-  component_id SERIAL PRIMARY KEY,
+  component_id UUID DEFAULT gen_random_uuid(),
   user_id SERIAL REFERENCES users(user_id),
-  github_repo VARCHAR(100) NOT NULL,
-  deployment_status VARCHAR(100) NOT NULL
+  github_repo TEXT NOT NULL,
+  deployment_status DEPLOYMENT_STATUS NOT NULL,
+  PRIMARY KEY(component_id)
 );
 
+DROP TABLE IF EXISTS workers CASCADE;
 CREATE TABLE workers (
-  worker_id SERIAL PRIMARY KEY,
-  worker_name VARCHAR(50) NOT NULL
+  worker_id UUID DEFAULT gen_random_uuid()
+  worker_name TEXT NOT NULL,
+  PRIMARY KEY(worker_id)
 );
 
+DROP TABLE IF EXISTS stats CASCADE;
 CREATE TABLE stats (
-  stat_id SERIAL PRIMARY KEY,
+  stat_id UUID DEFAULT gen_random_uuid(),
   worker_id SERIAL REFERENCES workers(worker_id),
   component_id SERIAL REFERENCES components(component_id),
   received_time TIMESTAMP NOT NULL,
-  color VARCHAR(20) NOT NULL,
-  stats_field VARCHAR(200) NOT NULL
+  color STATUS_COLOR NOT NULL,
+  stat_window_seconds DOUBLE PRECISION NOT NULL,
+  hits DOUBLE PRECISION NOT NULL,
+  avg_response_bytes DOUBLE PRECISION NOT NULL,
+  avg_ms_latency DOUBLE PRECISION NOT NULL,
+  ms_latency_percentiles JSONB NOT NULL,
+  PRIMARY KEY (stat_id)
 );
 
+DROP TABLE IF EXISTS logs CASCADE;
 CREATE TABLE logs (
-  log_id SERIAL PRIMARY KEY,
+  log_id UUID DEFAULT gen_random_uuid(),
   worker_id SERIAL REFERENCES workers(worker_id),
   component_id SERIAL REFERENCES components(component_id),
   execution_num INT NOT NULL,
   received_time TIMESTAMP NOT NULL,
-  log_text VARCHAR(400)
+  log_text TEXT,
+  log_error VASRCHAR(400),
+  PRIMARY KEY (log_id)
 );

--- a/create_tables.sql
+++ b/create_tables.sql
@@ -1,12 +1,17 @@
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
-DROP TYPE IF EXISTS STATUS_COLOR;
-CREATE TYPE STATUS_COLOR AS ENUM ('green', 'orange', 'red', 'grey');
+DROP TABLE IF EXISTS users CASCADE;
+DROP TABLE IF EXISTS components CASCADE;
+DROP TABLE IF EXISTS workers CASCADE;
+DROP TABLE IF EXISTS stats CASCADE;
+DROP TABLE IF EXISTS logs CASCADE;
 
+DROP TYPE IF EXISTS STATUS_COLOR;
 DROP TYPE IF EXISTS DEPLOYMENT_STATUS;
+
+CREATE TYPE STATUS_COLOR AS ENUM ('green', 'orange', 'red', 'grey');
 CREATE TYPE DEPLOYMENT_STATUS AS ENUM ('ready', 'paused');
 
-DROP TABLE IF EXISTS users CASCADE;
 CREATE TABLE users (
   user_id UUID DEFAULT gen_random_uuid(),
   email TEXT NOT NULL,
@@ -15,7 +20,6 @@ CREATE TABLE users (
   PRIMARY KEY (user_id)
 );
 
-DROP TABLE IF EXISTS components CASCADE;
 CREATE TABLE components (
   component_id UUID DEFAULT gen_random_uuid(),
   user_id UUID REFERENCES users(user_id),
@@ -24,14 +28,12 @@ CREATE TABLE components (
   PRIMARY KEY(component_id)
 );
 
-DROP TABLE IF EXISTS workers CASCADE;
 CREATE TABLE workers (
   worker_id UUID DEFAULT gen_random_uuid(),
   worker_name TEXT NOT NULL,
   PRIMARY KEY(worker_id)
 );
 
-DROP TABLE IF EXISTS stats CASCADE;
 CREATE TABLE stats (
   stat_id UUID DEFAULT gen_random_uuid(),
   worker_id UUID REFERENCES workers(worker_id),
@@ -46,7 +48,6 @@ CREATE TABLE stats (
   PRIMARY KEY (stat_id)
 );
 
-DROP TABLE IF EXISTS logs CASCADE;
 CREATE TABLE logs (
   log_id UUID DEFAULT gen_random_uuid(),
   worker_id UUID REFERENCES workers(worker_id),

--- a/create_tables.sql
+++ b/create_tables.sql
@@ -1,3 +1,9 @@
+DROP TABLE IF EXISTS logs CASCADE;
+DROP TABLE IF EXISTS stats CASCADE;
+DROP TABLE IF EXISTS workers CASCADE;
+DROP TABLE IF EXISTS components CASCADE;
+DROP TABLE IF EXISTS users CASCADE;
+
 CREATE TABLE users (
     user_id INT PRIMARY KEY          NOT NULL,
     email           VARCHAR(100)  NOT NULL,
@@ -10,4 +16,27 @@ CREATE TABLE components (
     user_id INT REFERENCES users(user_id),
     github_repo     VARCHAR(100)  NOT NULL,
     deployment_status  VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE workers (
+    worker_id INT PRIMARY KEY NOT NULL,
+    worker_name VARCHAR(50) NOT NULL
+);
+
+CREATE TABLE stats (
+    stat_id INT PRIMARY KEY NOT NULL,
+    worker_id INT REFERENCES workers(worker_id),
+    component_id INT REFERENCES components(component_id),
+    received_time TIMESTAMP NOT NULL,
+    color VARCHAR(20) NOT NULL,
+    stats_field VARCHAR(200) NOT NULL
+);
+
+CREATE TABLE logs (
+    log_id INT PRIMARY KEY NOT NULL,
+    worker_id INT REFERENCES workers(worker_id),
+    component_id INT REFERENCES components(component_id),
+    execution_num INT NOT NULL,
+    received_time TIMESTAMP NOT NULL,
+    log_text VARCHAR(400)
 );

--- a/create_tables.sql
+++ b/create_tables.sql
@@ -5,38 +5,38 @@ DROP TABLE IF EXISTS components CASCADE;
 DROP TABLE IF EXISTS users CASCADE;
 
 CREATE TABLE users (
-    user_id SERIAL PRIMARY KEY          NOT NULL,
-    email           VARCHAR(100)  NOT NULL,
-    github_token    VARCHAR(100)  NOT NULL,
-    github_username VARCHAR(100)  NOT NULL
+  user_id SERIAL PRIMARY KEY,
+  email VARCHAR(100) NOT NULL,
+  github_token VARCHAR(100) NOT NULL,
+  github_username VARCHAR(100) NOT NULL
 );
 
 CREATE TABLE components (
-    component_id SERIAL PRIMARY KEY          NOT NULL,
-    user_id SERIAL REFERENCES users(user_id),
-    github_repo     VARCHAR(100)  NOT NULL,
-    deployment_status  VARCHAR(100) NOT NULL
+  component_id SERIAL PRIMARY KEY,
+  user_id SERIAL REFERENCES users(user_id),
+  github_repo VARCHAR(100) NOT NULL,
+  deployment_status VARCHAR(100) NOT NULL
 );
 
 CREATE TABLE workers (
-    worker_id SERIAL PRIMARY KEY NOT NULL,
-    worker_name VARCHAR(50) NOT NULL
+  worker_id SERIAL PRIMARY KEY,
+  worker_name VARCHAR(50) NOT NULL
 );
 
 CREATE TABLE stats (
-    stat_id SERIAL PRIMARY KEY NOT NULL,
-    worker_id SERIAL REFERENCES workers(worker_id),
-    component_id SERIAL REFERENCES components(component_id),
-    received_time TIMESTAMP NOT NULL,
-    color VARCHAR(20) NOT NULL,
-    stats_field VARCHAR(200) NOT NULL
+  stat_id SERIAL PRIMARY KEY,
+  worker_id SERIAL REFERENCES workers(worker_id),
+  component_id SERIAL REFERENCES components(component_id),
+  received_time TIMESTAMP NOT NULL,
+  color VARCHAR(20) NOT NULL,
+  stats_field VARCHAR(200) NOT NULL
 );
 
 CREATE TABLE logs (
-    log_id SERIAL PRIMARY KEY NOT NULL,
-    worker_id SERIAL REFERENCES workers(worker_id),
-    component_id SERIAL REFERENCES components(component_id),
-    execution_num INT NOT NULL,
-    received_time TIMESTAMP NOT NULL,
-    log_text VARCHAR(400)
+  log_id SERIAL PRIMARY KEY,
+  worker_id SERIAL REFERENCES workers(worker_id),
+  component_id SERIAL REFERENCES components(component_id),
+  execution_num INT NOT NULL,
+  received_time TIMESTAMP NOT NULL,
+  log_text VARCHAR(400)
 );

--- a/create_tables.sql
+++ b/create_tables.sql
@@ -26,7 +26,7 @@ CREATE TABLE components (
 
 DROP TABLE IF EXISTS workers CASCADE;
 CREATE TABLE workers (
-  worker_id UUID DEFAULT gen_random_uuid()
+  worker_id UUID DEFAULT gen_random_uuid(),
   worker_name TEXT NOT NULL,
   PRIMARY KEY(worker_id)
 );

--- a/create_tables.sql
+++ b/create_tables.sql
@@ -1,0 +1,13 @@
+CREATE TABLE users (
+    user_id INT PRIMARY KEY          NOT NULL,
+    email           VARCHAR(100)  NOT NULL,
+    github_token    VARCHAR(100)  NOT NULL,
+    github_username VARCHAR(100)  NOT NULL
+);
+
+CREATE TABLE components (
+    component_id INT PRIMARY KEY          NOT NULL,
+    user_id INT REFERENCES users(user_id),
+    github_repo     VARCHAR(100)  NOT NULL,
+    deployment_status  VARCHAR(100) NOT NULL
+);

--- a/create_tables.sql
+++ b/create_tables.sql
@@ -5,37 +5,37 @@ DROP TABLE IF EXISTS components CASCADE;
 DROP TABLE IF EXISTS users CASCADE;
 
 CREATE TABLE users (
-    user_id INT PRIMARY KEY          NOT NULL,
+    user_id SERIAL PRIMARY KEY          NOT NULL,
     email           VARCHAR(100)  NOT NULL,
     github_token    VARCHAR(100)  NOT NULL,
     github_username VARCHAR(100)  NOT NULL
 );
 
 CREATE TABLE components (
-    component_id INT PRIMARY KEY          NOT NULL,
-    user_id INT REFERENCES users(user_id),
+    component_id SERIAL PRIMARY KEY          NOT NULL,
+    user_id SERIAL REFERENCES users(user_id),
     github_repo     VARCHAR(100)  NOT NULL,
     deployment_status  VARCHAR(100) NOT NULL
 );
 
 CREATE TABLE workers (
-    worker_id INT PRIMARY KEY NOT NULL,
+    worker_id SERIAL PRIMARY KEY NOT NULL,
     worker_name VARCHAR(50) NOT NULL
 );
 
 CREATE TABLE stats (
-    stat_id INT PRIMARY KEY NOT NULL,
-    worker_id INT REFERENCES workers(worker_id),
-    component_id INT REFERENCES components(component_id),
+    stat_id SERIAL PRIMARY KEY NOT NULL,
+    worker_id SERIAL REFERENCES workers(worker_id),
+    component_id SERIAL REFERENCES components(component_id),
     received_time TIMESTAMP NOT NULL,
     color VARCHAR(20) NOT NULL,
     stats_field VARCHAR(200) NOT NULL
 );
 
 CREATE TABLE logs (
-    log_id INT PRIMARY KEY NOT NULL,
-    worker_id INT REFERENCES workers(worker_id),
-    component_id INT REFERENCES components(component_id),
+    log_id SERIAL PRIMARY KEY NOT NULL,
+    worker_id SERIAL REFERENCES workers(worker_id),
+    component_id SERIAL REFERENCES components(component_id),
     execution_num INT NOT NULL,
     received_time TIMESTAMP NOT NULL,
     log_text VARCHAR(400)

--- a/populate_tables.sql
+++ b/populate_tables.sql
@@ -1,0 +1,8 @@
+INSERT INTO users(email, github_token, github_username)
+VALUES('test@test.com', '12345', 'test');
+
+INSERT INTO components(user_id, github_repo, deployment_status)
+VALUES(1, 'test_repo', 'deployed');
+
+INSERT INTO workers(name)
+VALUES('Tatooine');


### PR DESCRIPTION
The `create_tables` script creates PSQL tables in accordance with the V9 spec. The `populate_tables` script creates fake data for testing purposes. 

I think the `deployment_status` and `color` fields should be converted to enums, any thoughts on what values should be associated with them?